### PR TITLE
[Implementation] api helpers added

### DIFF
--- a/.idea/dictionaries/chinm.xml
+++ b/.idea/dictionaries/chinm.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="chinm">
     <words>
+      <w>fineract</w>
       <w>flowable</w>
       <w>grandolf</w>
       <w>livedata</w>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
@@ -20,7 +19,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,8 +35,11 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
+
     //testing dependency
     androidTestImplementation "com.google.truth:truth:1.1.3"
+    implementation 'com.github.openMF:fineract-client:1.0.1'
+
 
     // Retrofit and OkHttp
     def retrofit_version = '2.9.0'

--- a/core/src/main/java/org/mifos/core/apihelper/DataState.kt
+++ b/core/src/main/java/org/mifos/core/apihelper/DataState.kt
@@ -1,0 +1,14 @@
+package org.mifos.core.apihelper
+
+import java.lang.Exception
+
+/**
+ * This class is used as a data interface between network calls and
+ * business logic.
+ * @author Danish Jamal - http://github.com/danishjamal104/
+ * @see apiRequest
+ */
+sealed class DataState<out R> {
+    data class Success<out T>(val data: T) : DataState<T>()
+    data class Error(val exception: Exception) : DataState<Nothing>()
+}

--- a/core/src/main/java/org/mifos/core/apihelper/RequestUtils.kt
+++ b/core/src/main/java/org/mifos/core/apihelper/RequestUtils.kt
@@ -1,0 +1,95 @@
+package org.mifos.core.apihelper
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.mifos.core.data.EntityMapper
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.lang.Exception
+
+/**
+ * Contains the generic helper function for executing the api request
+ * by the FineractClient services
+ * @author Danish Jamal - http://github.com/danishjamal104/
+ */
+
+/**
+ * Queues the call request
+ * @param IN the generic data type of Call<T>
+ * @param call the call instance of type [Call], which is to be queued
+ * @param onResponse lambda function called when response is returned
+ * @param onFailure lambda function called when failure occurs
+ */
+private fun <IN> callRequest(
+    call: Call<IN>,
+    onResponse: (response: Response<IN>) -> Unit,
+    onFailure: (exception: Exception) -> Unit
+) {
+    call.enqueue(object : Callback<IN> {
+        override fun onResponse(call: Call<IN>, response: Response<IN>) {
+            if (response.body() != null) {
+                onResponse(response)
+            } else {
+                val exp = Exception(response.errorBody().toString())
+                onFailure(exp)
+            }
+        }
+
+        override fun onFailure(call: Call<IN>, t: Throwable) {
+            onFailure(t as Exception)
+        }
+    })
+}
+
+/**
+ * Queues the call request and returns the LiveData of [DataState],
+ * of generic response form retrofit.
+ * For getting specific data type user @see apiRequest<IN, OUT>
+ * @param IN the generic data type of object to be returned
+ * @param call the call instance of type [Call], which is to be executed
+ * @return [LiveData] object of generic type [IN] of [DataState]
+ */
+fun <IN> apiRequest(call: Call<IN>): LiveData<DataState<IN>> {
+    val liveData = MutableLiveData<DataState<IN>>()
+    callRequest(call, { response ->
+        if (response.body() != null) {
+            liveData.postValue(DataState.Success(response.body()!!))
+        } else {
+            val exp = Exception(response.errorBody().toString())
+            liveData.postValue(DataState.Error(exp))
+        }
+    }, {
+        liveData.postValue(DataState.Error(it))
+    })
+    return liveData
+}
+
+/**
+ * Queues the call request and returns the LiveData of [DataState],
+ * of [OUT] generic type. Here [entityMapper] is used for converting
+ * the generic response of retrofit to specific [OUT] type.
+ * @param IN the generic data type of object returned by retrofit call
+ * @param OUT the generic data type of object to be returned
+ * @param call the call instance of type [Call], which is to be executed
+ * @param entityMapper use to convert [IN] to [OUT]
+ * @return [LiveData] object of generic type [OUT] of [DataState]
+ */
+fun <IN, OUT> apiRequest(
+    call: Call<IN>,
+    entityMapper: EntityMapper<IN, OUT>
+): LiveData<DataState<OUT>> {
+    val liveData = MutableLiveData<DataState<OUT>>()
+    callRequest(call, { response ->
+        if (response.body() != null) {
+            val body = entityMapper.mapFromEntity(response.body()!!)
+            liveData.postValue(DataState.Success(body))
+        } else {
+            val exp = Exception(response.errorBody().toString())
+            liveData.postValue(DataState.Error(exp))
+        }
+    }, {
+        liveData.postValue(DataState.Error(it))
+    })
+    return liveData
+}

--- a/core/src/main/java/org/mifos/core/data/EntityMapper.kt
+++ b/core/src/main/java/org/mifos/core/data/EntityMapper.kt
@@ -1,0 +1,14 @@
+package org.mifos.core.data
+
+/**
+ * The generic interface for mapping data from api to specific domain,
+ * create concrete class for specific models implementing this mapper
+ * and use it while making the api request
+ * @author Danish Jamal - http://github.com/danishjamal104/
+ * @param Entity the generic class which belongs outside of this app
+ * @param DomainModel the generic class which holds data for this specific app/domain
+ */
+interface EntityMapper<Entity, DomainModel> {
+    fun mapFromEntity(entity: Entity): DomainModel
+    fun mapToEntity(domainModel: DomainModel): Entity
+}


### PR DESCRIPTION
**Below are the major changes**
- Added `com.github.openMF:fineract-client:1.0.1` dependency.
- Implemented `DataState` sealed class to be used as a data interface between network calls and business logic.
- Defined `EntityMapper` interface, to be used for mapping data from api entity model to specific domain model.
- New file `RequestUtils.kt` consisting of generic function for executing and getting `LiveData` object.

**How to use RequestUtils**
- It contains two function:
    -  `apiRequest(call, userMapper)`: Use this for converting data to specific domain model, instead of getting the generic retrofit response.
    - `apiRequest(call)`: Use this for getting the generic retrofit response.

below is the sample code snippet of how these methods can be use. (These snippets are base on Fineract-1.0.1 version and may look different in actual implementation)
```kotlin
    val userMapper = UserMapper()
    val call = FineractApiClient().authApi.authenticate("mifos", "password")
    // in this request the result(it.data) will be of type User, viz a domain model
    apiRequest(call, userMapper).observeForever {
        when (it) {
            is DataState.Error -> {
                it.exception
                // TODO: 15/06/21 handle exception cases here
            }
            is DataState.Success -> {
                it.data
                // TODO: 15/06/21 handle data here
            }
        }
    }
   // in this case result(it.data) will be of type PostAuthenticationResponse as returned by authenticate api
    apiRequest(call).observeForever {
        when (it) {
            is DataState.Error -> {
                it.exception
                // TODO: 15/06/21 handle exception cases here
            }
            is DataState.Success -> {
                it.data
                // TODO: 15/06/21 handle data here
            }
        }
    }
```

**UserMapper sample code**
```kotlin
class UserMapper : EntityMapper<PostAuthenticationResponse, User> {

    override fun mapFromEntity(entity: PostAuthenticationResponse): User {
        val role = mutableListOf<Role>()
        entity.roles.forEach {
            role.add(Role(it.id.toInt(), it.name, "test", false))
        }

        return User(
            entity.username,
            entity.userId.toInt(),
            entity.base64EncodedAuthenticationKey,
            entity.isAuthenticated,
            entity.officeId.toInt(),
            entity.officeName,
            entity.staffId.toInt(),
            entity.staffDisplayName,
            role,
            entity.permissions
        )
    }

    override fun mapToEntity(domainModel: User): PostAuthenticationResponse {
        TODO("Not yet implemented")
    }
}
```

**Benefit of using this approach**
- This implementation is based on clean code architecture.
- Take a look at return type of apiRequest, it is always `DataState`, hence for changing or adding anything in network part we only need to change the network layer without modifying the client side.
- Supports the mapper hence it is very convenient to define custom mapper and use for chaining data type from one to another at sdk level.