### PR TITLE
fineract client version updated, and tested the api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,16 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         multiDexEnabled true
-        applicationId "org.mifos"
-        minSdkVersion 15
-        targetSdkVersion 29
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -24,18 +23,18 @@ android {
         }
     }
 
-    packagingOptions {
-        exclude 'META-INF/rxjava.properties'
-    }
-
     lintOptions {
         abortOnError false
     }
+
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    //implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.multidex:multidex:2.0.0'
+    implementation ("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"){
+        force true
+    }
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.13'
@@ -43,13 +42,27 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // RecyclerView and CardView
-    implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha03'
     implementation 'androidx.cardview:cardview:1.0.0'
+
+    implementation "io.reactivex:rxandroid:$rxAndroidVersion"
+    implementation "io.reactivex:rxjava:$rxJavaVersion"
 
     // Lifecycle
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
 
-    implementation 'androidx.multidex:multidex:2.0.0'
+    //Square dependencies
+    implementation("com.squareup.retrofit2:retrofit:$retrofitVersionLatest") {
+        // exclude Retrofit’s OkHttp peer-dependency module and define your own module import
+        exclude module: 'okhttp'
+    }
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersionLatest"
+    implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersionLatest"
+    implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersionLatest"
+    implementation "com.squareup.okhttp3:okhttp:$okHttp3Version"
+    implementation "com.squareup.okhttp3:logging-interceptor:$okHttp3Version"
 
-    implementation project(':core')
+    implementation project(path: ':core')
+    implementation ("com.github.danishjamal104:fineract-client:$fineractClientVersion") {
+        exclude module: 'okhttp'
+    }
 }

--- a/app/src/main/java/org/mifos/ui/HomeActivity.kt
+++ b/app/src/main/java/org/mifos/ui/HomeActivity.kt
@@ -1,14 +1,60 @@
 package org.mifos.ui
 
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import org.apache.fineract.client.models.PostAuthenticationResponse
 import org.mifos.R
+import org.mifos.core.apimanager.BaseApiManager
+import rx.Subscriber
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import java.util.*
 
 class HomeActivity : AppCompatActivity(){
+
+    val base_url = "https://demo.fineract.dev/fineract-provider/api/v1/"
+    val tenant = "default"
+    lateinit var baseApiManager: BaseApiManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_home)
+
+
+        baseApiManager = BaseApiManager.getInstance()
+        baseApiManager.createService("mifos", "password", base_url, tenant)
+
+        val body = "{\"username\": \"mifos\", \"password\": \"password\"}"
+
+        baseApiManager.getAuthApi().authenticate(true, body)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(Schedulers.io())
+            .subscribe(object : Subscriber<PostAuthenticationResponse>() {
+                override fun onCompleted() {
+                    Log.i("subscriber", "completed")
+                    setText("completed")
+                }
+
+                override fun onError(e: Throwable?) {
+                    Log.i("subscriber", "error: ${e?.localizedMessage}")
+                    setText("error: ${e?.localizedMessage}")
+                }
+
+                override fun onNext(t: PostAuthenticationResponse?) {
+                    Log.i("subscriber", "next: ${t.toString()}")
+                    setText("next: ${t.toString()}")
+                }
+
+            })
+    }
+
+
+    fun setText(text: String) {
+        findViewById<TextView>(R.id.text).text = text
     }
 
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -5,13 +5,12 @@
     android:layout_height="match_parent"
     tools:context=".ui.HomeActivity">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_home"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="@dimen/recyclerview_default"
-        tools:listitem="@layout/layout_api_item">
-
-    </androidx.recyclerview.widget.RecyclerView>
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:layout_centerInParent="true"
+        android:padding="32dp"/>
 
 </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,25 @@ buildscript {
     }
 }
 
+ext {
+    // Sdk and tools
+    minSdkVersion = 15
+    targetSdkVersion = 28
+    compileSdkVersion = 28
+    buildToolsVersion = '28.0.3'
+
+    // App dependencies
+    supportLibraryVersion = '27.1.1'
+    espressoVersion = '2.2.2'
+    retrofitVersionLatest = '2.1.0'
+    okHttp3Version = '3.5.0'
+    preference = '1.1.0'
+    rxJavaVersion = '1.1.4'
+    rxAndroidVersion = '1.1.0'
+
+    fineractClientVersion = '2.4.1-alpha'
+}
+
 allprojects {
     repositories {
         google()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 29
@@ -37,29 +36,28 @@ dependencies {
     //testing dependency
     androidTestImplementation "com.google.truth:truth:1.1.3"
 
-    implementation 'com.github.openMF:fineract-client:2.1.0-alpha'
-
     implementation ("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"){
-        version {
-            strictly "$kotlin_version"
-        }
+        force true
     }
-
-
-    // Retrofit and OkHttp
-    def retrofit_version = '2.9.0'
-    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-scalars:$retrofit_version"
-    implementation "com.squareup.retrofit2:adapter-rxjava:$retrofit_version"
 
     implementation 'io.reactivex:rxjava:1.1.4'
 
-    def okhttp_version = '3.14.9'
-    implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
+    //Square dependencies
+    implementation("com.squareup.retrofit2:retrofit:$retrofitVersionLatest") {
+        // exclude Retrofit’s OkHttp peer-dependency module and define your own module import
+        exclude module: 'okhttp'
+    }
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersionLatest"
+    implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersionLatest"
+    implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersionLatest"
+    implementation "com.squareup.okhttp3:okhttp:$okHttp3Version"
+    implementation "com.squareup.okhttp3:logging-interceptor:$okHttp3Version"
 
     //Shared Preferences
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation "androidx.preference:preference:$preference"
+
+    implementation ("com.github.danishjamal104:fineract-client:$fineractClientVersion") {
+        exclude module: 'okhttp'
+    }
 
 }

--- a/core/src/main/java/org/mifos/core/apimanager/BaseApiManager.kt
+++ b/core/src/main/java/org/mifos/core/apimanager/BaseApiManager.kt
@@ -2,7 +2,6 @@ package org.mifos.core.apimanager
 
 import org.apache.fineract.client.services.*
 import org.apache.fineract.client.util.FineractClient
-import org.mifos.core.sharedpreference.UserPreferences
 
 interface BaseApiManager {
 

--- a/core/src/main/java/org/mifos/core/apimanager/BaseApiManagerImpl.kt
+++ b/core/src/main/java/org/mifos/core/apimanager/BaseApiManagerImpl.kt
@@ -4,7 +4,6 @@ import com.google.gson.Gson
 import org.apache.fineract.client.services.*
 import org.apache.fineract.client.util.FineractClient
 import org.mifos.core.apimanager.MifosOkHttpClient.mifosOkHttpClient
-import org.mifos.core.sharedpreference.UserPreferences
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
@@ -27,7 +26,8 @@ class BaseApiManagerImpl : BaseApiManager {
         builder.retrofitBuilder.addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create(Gson()))
-            .addCallAdapterFactory(RxJavaCallAdapterFactory.create()).client(mifosOkHttpClient)
+            .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+            .client(mifosOkHttpClient)
 
         client = builder.build()
     }

--- a/core/src/main/java/org/mifos/core/apimanager/MifosOkHttpClient.kt
+++ b/core/src/main/java/org/mifos/core/apimanager/MifosOkHttpClient.kt
@@ -38,22 +38,16 @@ object MifosOkHttpClient {
             sslContext.init(null, trustAllCerts, SecureRandom())
             val builder = OkHttpClient.Builder()
 
-            builder.sslSocketFactory(sslContext.socketFactory, trustAllCerts[0] as X509TrustManager)
+            builder.sslSocketFactory(sslContext.socketFactory)
             builder.hostnameVerifier(HostnameVerifier { _, _ -> true })
-
-            //Enable Full Body Logging
 
             //Enable Full Body Logging
             val logger = HttpLoggingInterceptor()
             logger.setLevel(HttpLoggingInterceptor.Level.BODY)
 
             //Setting Timeout 30 Seconds
-
-            //Setting Timeout 30 Seconds
             builder.connectTimeout(60, TimeUnit.SECONDS)
             builder.readTimeout(60, TimeUnit.SECONDS)
-
-            //Interceptor :> Full Body Logger and ApiRequest Header
 
             //Interceptor :> Full Body Logger and ApiRequest Header
             builder.addInterceptor(logger)


### PR DESCRIPTION
Fixes #17 

**Below are the major changes**
1. Downgraded version to support `Fineract Client` and for easy integration `Android Client`.
    ```
    // Sdk and tools
    minSdkVersion = 15
    targetSdkVersion = 28
    compileSdkVersion = 28
    buildToolsVersion = '28.0.3'

    // App dependencies
    supportLibraryVersion = '27.1.1'
    espressoVersion = '2.2.2'
    retrofitVersionLatest = '2.1.0'
    okHttp3Version = '3.5.0'
    preference = '1.1.0'
    rxJavaVersion = '1.1.4'
    rxAndroidVersion = '1.1.0'

    fineractClientVersion = '2.4.1-alpha'
    ```
2. Added android specific dependency in app module.
3. Added http basic authentication sample code(Run the app and see the log for complete returned `PostAuthenticatonResponse`)

**PS**
All these changes are tested after creating the alpha release on my local repository. For testing the latest version of library add below dependency:
`implementation 'com.github.danishjamal104:mifos-android-sdk-arch:3.0.1-alpha'`