### PR TITLE
insecure support added, fineract client version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ To add library in your gradle project follow the steps below:
 2. Add the dependency
    ```groovy
    dependencies {
-       implementation 'com.github.openMF:mifos-android-sdk-arch:1.0.0'
+       def sdk_Version = '1.0.0'
+       implementation "com.github.openMF:mifos-android-sdk-arch:$sdk_Version"
    }
    ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,5 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okHttp3Version"
 
     implementation project(path: ':core')
-    implementation ("com.github.danishjamal104:fineract-client:$fineractClientVersion") {
-        exclude module: 'okhttp'
-    }
+    implementation ("com.github.openMF:fineract-client:$fineractClientVersion")
 }

--- a/app/src/main/java/org/mifos/ui/HomeActivity.kt
+++ b/app/src/main/java/org/mifos/ui/HomeActivity.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import org.apache.fineract.client.models.GetClientsClientIdAccountsResponse
+import org.apache.fineract.client.models.GetClientsClientIdResponse
 import org.apache.fineract.client.models.PostAuthenticationResponse
 import org.mifos.R
 import org.mifos.core.apimanager.BaseApiManager
@@ -47,6 +49,7 @@ class HomeActivity : AppCompatActivity(){
                 override fun onNext(t: PostAuthenticationResponse?) {
                     Log.i("subscriber", "next: ${t.toString()}")
                     setText("next: ${t.toString()}")
+                    getClientAccounts(1)
                 }
 
             })
@@ -55,6 +58,52 @@ class HomeActivity : AppCompatActivity(){
 
     fun setText(text: String) {
         findViewById<TextView>(R.id.text).text = text
+    }
+
+    fun getClient(clientId: Long) {
+        baseApiManager.getClientsApi().retrieveOne11(clientId, false)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(Schedulers.io())
+            .subscribe(object : Subscriber<GetClientsClientIdResponse>() {
+                override fun onCompleted() {
+                    Log.i("subscriber", "completed")
+                    setText("completed")
+                }
+
+                override fun onError(e: Throwable?) {
+                    Log.i("subscriber", "error: ${e?.localizedMessage}")
+                    setText("error: ${e?.localizedMessage}")
+                }
+
+                override fun onNext(t: GetClientsClientIdResponse?) {
+                    Log.i("subscriber", "next: ${t.toString()}")
+                    setText("next: ${t.toString()}")
+                }
+
+            })
+    }
+
+    fun getClientAccounts(clientId: Long) {
+        baseApiManager.getClientsApi().retrieveAssociatedAccounts(clientId)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(Schedulers.io())
+            .subscribe(object : Subscriber<GetClientsClientIdAccountsResponse>() {
+                override fun onCompleted() {
+                    Log.i("subscriber", "completed")
+                    setText("completed")
+                }
+
+                override fun onError(e: Throwable?) {
+                    Log.i("subscriber", "error: ${e?.localizedMessage}")
+                    setText("error: ${e?.localizedMessage}")
+                }
+
+                override fun onNext(t: GetClientsClientIdAccountsResponse?) {
+                    Log.i("subscriber", "next: ${t.toString()}")
+                    setText("next: ${t.toString()}")
+                }
+
+            })
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
     rxJavaVersion = '1.1.4'
     rxAndroidVersion = '1.1.0'
 
-    fineractClientVersion = '2.4.1-alpha'
+    fineractClientVersion = '2.0.1'
 }
 
 allprojects {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,8 +56,6 @@ dependencies {
     //Shared Preferences
     implementation "androidx.preference:preference:$preference"
 
-    implementation ("com.github.danishjamal104:fineract-client:$fineractClientVersion") {
-        exclude module: 'okhttp'
-    }
+    implementation ("com.github.openMF:fineract-client:$fineractClientVersion")
 
 }

--- a/core/src/main/java/org/mifos/core/apimanager/BaseApiManager.kt
+++ b/core/src/main/java/org/mifos/core/apimanager/BaseApiManager.kt
@@ -11,7 +11,7 @@ interface BaseApiManager {
         }
     }
 
-    fun createService(username: String, password: String, baseUrl: String, tenant: String)
+    fun createService(username: String, password: String, baseUrl: String, tenant: String = "default", secured: Boolean = true)
 
     fun getClient(): FineractClient
 

--- a/core/src/main/java/org/mifos/core/apimanager/BaseApiManagerImpl.kt
+++ b/core/src/main/java/org/mifos/core/apimanager/BaseApiManagerImpl.kt
@@ -17,11 +17,12 @@ class BaseApiManagerImpl : BaseApiManager {
 
     private lateinit var client: FineractClient
 
-    override fun createService(username: String, password: String, baseUrl: String, tenant: String) {
+    override fun createService(username: String, password: String, baseUrl: String, tenant: String, secured: Boolean) {
         val builder = FineractClient.builder()
             .baseURL(baseUrl)
             .basicAuth(username, password)
             .tenant(tenant)
+            .insecure(!secured)
 
         builder.retrofitBuilder.addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(ScalarsConverterFactory.create())


### PR DESCRIPTION
**Description**
1. Updated Fineract Client version to `2.0.1`.
2. Added insecure support fo local testing with `localhost:8443`(No need to handle the trust managers).
3. Added `getClient` and `getClientAccounts` testing code in `HomeActivity`.
4. Updated version in readme.

**This app make changes to below module/s**
- [x] app
- [x] core
- [x] other/documentation

**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them