### PR TITLE
cache added in Project Build workflow

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,6 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      # Cache dependencies
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.OS }}-gradle-cache-${{ hashFiles('**/build.gradle') }}
+
       - name: Set Up JDK
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
**Description**
Added cached support in `Project Build` GitHub workflow.


**This app make changes to below module/s**
- [ ] app
- [ ] core
- [ ] other/documentation
- [x] CI/CD

**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [x] Build the project with `./gradlew build` to make sure you didn't break anything
- [x] Added the comments particularly in hard-to-understand areas
- [x] In case of multiple commits please squash them